### PR TITLE
Add git setup on session start

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ using the latest Ubuntu image.
   `devcontainer.json` from `.devcontainer/ENV` (or the default location if not
   provided). The session is created if it doesn't exist. We derive the git repo
   from the current folder. If there is a git repo but no GitHub repo, create it
-  under `githuborg` from the config.
+  under `githuborg` from the config. When opening a session we also ensure the
+  `origin` remote exists (creating it with `gh repo create` when missing) and
+  create a local branch matching the session name if it doesn't already exist.
 - forest kill $name # destroy the session.
 - forest ls # list all sessions
 


### PR DESCRIPTION
## Summary
- create origin repo via gh if missing and make session branch
- document git setup logic in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e86bb4ba0832682f2cc2818840843