### PR TITLE
Fix forest sessions exiting immediately

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -211,10 +211,13 @@ fn open_session(
         println!("Session {} already exists", name);
     } else {
         if verbose {
-            println!("Running: podman run -d --name {} {}", name, image);
+            println!(
+                "Running: podman run -d --name {} {} sleep infinity",
+                name, image
+            );
         }
         let status = Command::new("podman")
-            .args(["run", "-d", "--name", name, image])
+            .args(["run", "-d", "--name", name, image, "sleep", "infinity"])
             .status()
             .map_err(|e| {
                 if e.kind() == std::io::ErrorKind::NotFound {


### PR DESCRIPTION
## Summary
- keep podman containers alive by running `sleep infinity`
- adjust verbose log output

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684ea57f02dc8326a8cd699a18eb1d09