### PR TITLE
Mount repo root path for worktree containers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -250,8 +250,10 @@ fn open_session(
     } else {
         if verbose {
             println!(
-                "Running: podman run -d --name {} -v {}:/repo -v {}:/code -w /code {} sleep infinity",
+                "Running: podman run -d --name {} -v {}:/repo -v {}:{} -v {}:/code -w /code {} sleep infinity",
                 name,
+                repo_root.display(),
+                repo_root.display(),
                 repo_root.display(),
                 worktree_path.display(),
                 image
@@ -264,6 +266,8 @@ fn open_session(
             .arg(name)
             .arg("-v")
             .arg(format!("{}:/repo", repo_root.display()))
+            .arg("-v")
+            .arg(format!("{}:{}", repo_root.display(), repo_root.display()))
             .arg("-v")
             .arg(format!("{}:/code", worktree_path.display()))
             .arg("-w")


### PR DESCRIPTION
## Summary
- ensure git worktrees can find their parent repository by mounting the repo at its original path

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ec9aabf2c83268d778d4d28cbe83d