### PR TITLE
Use init process in sessions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,7 @@ fn open_session(
     } else {
         if verbose {
             println!(
-                "Running: podman run -d --name {} -v {}:/repo -v {}:{} -v {}:/code -w /code {} sleep infinity",
+                "Running: podman run -d --name {} -v {}:/repo -v {}:{} -v {}:/code -w /code --init {} sleep infinity",
                 name,
                 repo_root.display(),
                 repo_root.display(),
@@ -272,6 +272,7 @@ fn open_session(
             .arg(format!("{}:/code", worktree_path.display()))
             .arg("-w")
             .arg("/code")
+            .arg("--init")
             .arg(image)
             .arg("sleep")
             .arg("infinity")


### PR DESCRIPTION
## Summary
- use `podman run --init` so that the pid1 process can handle signals properly

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684ed07135c88326841fb3f5c462ee4f