### PR TITLE
Cache apt packages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,15 +20,10 @@ jobs:
         run: |
           git config --global user.name "CI"
           git config --global user.email "ci@example.com"
-      - name: Install gh and podman
-        run: |
-          (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
-            && sudo mkdir -p -m 755 /etc/apt/keyrings \
-            && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-            && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-            && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
-            && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
-            && sudo apt update \
-            && sudo apt install gh podman -y
+      - name: Cache gh and podman
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: gh podman
+          version: 1
       - name: Run tests
         run: cargo test --verbose


### PR DESCRIPTION
## Summary
- use `cache-apt-pkgs-action` to install and cache `gh` and `podman`

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684ed1afb04c832692e5d4961ed9174a