### PR TITLE
Support building devcontainers from Dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+# .devcontainer/Dockerfile
+FROM mcr.microsoft.com/devcontainers/rust:latest
+
+RUN curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Rust Development Environment",
-    "image": "mcr.microsoft.com/devcontainers/rust:latest",
+    "build": { "dockerfile": "Dockerfile" },
     "customizations": {
         "vscode": {
             "extensions": [

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The repository must include a `devcontainer.json` file. The tool looks for:
 * `.devcontainer/devcontainer.json`
 * `.devcontainer/<env>/devcontainer.json` when using `--devcontainer-env <env>`
 
-The selected `devcontainer.json` must specify an `image` field which is used
-to launch the container.
+The selected `devcontainer.json` must specify either an `image` field or a
+`build.dockerfile` which will be built and used to launch the container.
 
 If no configuration is found, `forest` will scaffold `.devcontainer/devcontainer.json`
 using the latest Ubuntu image.

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -46,6 +46,30 @@ case "$cmd" in
     sh -c "$input"
     exit 0
     ;;
+  build)
+    tag=""
+    dockerfile=""
+    context=""
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -t)
+          tag=$2
+          shift 2
+          ;;
+        -f)
+          dockerfile=$2
+          shift 2
+          ;;
+        *)
+          context=$1
+          shift
+          ;;
+      esac
+    done
+    echo "$dockerfile $context" > "$PODMAN_STATE/${tag}.build"
+    touch "$PODMAN_STATE/$tag"
+    exit 0
+    ;;
 esac
 exit 1
 "#;
@@ -53,59 +77,53 @@ exit 1
 #[test]
 fn new_session_branch_inside_container() {
     let repo_dir = tempdir().unwrap();
-    assert!(
-        Command::new("git")
-            .args(["init", "-b", "main"])
-            .current_dir(&repo_dir)
-            .status()
-            .unwrap()
-            .success()
-    );
+    assert!(Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(&repo_dir)
+        .status()
+        .unwrap()
+        .success());
     fs::write(repo_dir.path().join("file"), "hello").unwrap();
-    assert!(
-        Command::new("git")
-            .args(["add", "."])
-            .current_dir(&repo_dir)
-            .status()
-            .unwrap()
-            .success()
-    );
-    assert!(
-        Command::new("git")
-            .args(["commit", "-m", "init"])
-            .current_dir(&repo_dir)
-            .status()
-            .unwrap()
-            .success()
-    );
+    assert!(Command::new("git")
+        .args(["add", "."])
+        .current_dir(&repo_dir)
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(&repo_dir)
+        .status()
+        .unwrap()
+        .success());
 
     let home_dir = repo_dir.path().join("home");
     fs::create_dir(&home_dir).unwrap();
-    let repo_name = repo_dir
-        .path()
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap();
-    let worktree_path = home_dir.join("worktrees").join(repo_name).join("new-branch");
+    let repo_name = repo_dir.path().file_name().unwrap().to_str().unwrap();
+    let worktree_path = home_dir
+        .join("worktrees")
+        .join(repo_name)
+        .join("new-branch");
 
     let podman_dir = tempdir().unwrap();
     let podman_path = podman_dir.path().join("podman");
     fs::write(&podman_path, STUB_SCRIPT).unwrap();
-    assert!(
-        Command::new("chmod")
-            .arg("+x")
-            .arg(&podman_path)
-            .status()
-            .unwrap()
-            .success()
-    );
+    assert!(Command::new("chmod")
+        .arg("+x")
+        .arg(&podman_path)
+        .status()
+        .unwrap()
+        .success());
 
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_forest"));
     cmd.current_dir(&repo_dir);
     cmd.env(
         "PATH",
-        format!("{}:{}", podman_dir.path().display(), std::env::var("PATH").unwrap()),
+        format!(
+            "{}:{}",
+            podman_dir.path().display(),
+            std::env::var("PATH").unwrap()
+        ),
     );
     cmd.env("HOME", &home_dir);
     cmd.env("WORKTREE_PATH", &worktree_path);
@@ -136,70 +154,62 @@ fn new_session_branch_inside_container() {
 #[test]
 fn mounts_repo_and_worktree() {
     let repo_dir = tempdir().unwrap();
-    assert!(
-        Command::new("git")
-            .args(["init", "-b", "main"])
-            .current_dir(&repo_dir)
-            .status()
-            .unwrap()
-            .success()
-    );
+    assert!(Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(&repo_dir)
+        .status()
+        .unwrap()
+        .success());
     fs::write(repo_dir.path().join("file"), "hello").unwrap();
-    assert!(
-        Command::new("git")
-            .args(["add", "."])
-            .current_dir(&repo_dir)
-            .status()
-            .unwrap()
-            .success()
-    );
-    assert!(
-        Command::new("git")
-            .args(["commit", "-m", "init"])
-            .current_dir(&repo_dir)
-            .status()
-            .unwrap()
-            .success()
-    );
+    assert!(Command::new("git")
+        .args(["add", "."])
+        .current_dir(&repo_dir)
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(&repo_dir)
+        .status()
+        .unwrap()
+        .success());
 
     // create unrelated worktree which should not be mounted
     let other_wt = repo_dir.path().join("otherwt");
-    assert!(
-        Command::new("git")
-            .args(["worktree", "add", "-b", "other", other_wt.to_str().unwrap()])
-            .current_dir(&repo_dir)
-            .status()
-            .unwrap()
-            .success()
-    );
+    assert!(Command::new("git")
+        .args(["worktree", "add", "-b", "other", other_wt.to_str().unwrap()])
+        .current_dir(&repo_dir)
+        .status()
+        .unwrap()
+        .success());
 
     let home_dir = repo_dir.path().join("home");
     fs::create_dir(&home_dir).unwrap();
-    let repo_name = repo_dir
-        .path()
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap();
-    let worktree_path = home_dir.join("worktrees").join(repo_name).join("new-branch");
+    let repo_name = repo_dir.path().file_name().unwrap().to_str().unwrap();
+    let worktree_path = home_dir
+        .join("worktrees")
+        .join(repo_name)
+        .join("new-branch");
 
     let podman_dir = tempdir().unwrap();
     let podman_path = podman_dir.path().join("podman");
     fs::write(&podman_path, STUB_SCRIPT).unwrap();
-    assert!(
-        Command::new("chmod")
-            .arg("+x")
-            .arg(&podman_path)
-            .status()
-            .unwrap()
-            .success()
-    );
+    assert!(Command::new("chmod")
+        .arg("+x")
+        .arg(&podman_path)
+        .status()
+        .unwrap()
+        .success());
 
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_forest"));
     cmd.current_dir(&repo_dir);
     cmd.env(
         "PATH",
-        format!("{}:{}", podman_dir.path().display(), std::env::var("PATH").unwrap()),
+        format!(
+            "{}:{}",
+            podman_dir.path().display(),
+            std::env::var("PATH").unwrap()
+        ),
     );
     cmd.env("HOME", &home_dir);
     cmd.env("WORKTREE_PATH", &worktree_path);
@@ -222,4 +232,84 @@ fn mounts_repo_and_worktree() {
     assert!(volumes.contains(&format!("{}:/repo", repo_dir.path().display())));
     assert!(volumes.contains(&format!("{}:/code", worktree_path.display())));
     assert!(!volumes.contains(other_wt.to_str().unwrap()));
+}
+
+#[test]
+fn builds_image_when_using_dockerfile() {
+    let repo_dir = tempdir().unwrap();
+    assert!(Command::new("git")
+        .args(["init", "-b", "main"])
+        .current_dir(&repo_dir)
+        .status()
+        .unwrap()
+        .success());
+    fs::write(repo_dir.path().join("file"), "hello").unwrap();
+    assert!(Command::new("git")
+        .args(["add", "."])
+        .current_dir(&repo_dir)
+        .status()
+        .unwrap()
+        .success());
+    assert!(Command::new("git")
+        .args(["commit", "-m", "init"])
+        .current_dir(&repo_dir)
+        .status()
+        .unwrap()
+        .success());
+
+    let dev_dir = repo_dir.path().join(".devcontainer");
+    fs::create_dir(&dev_dir).unwrap();
+    fs::write(
+        dev_dir.join("devcontainer.json"),
+        r#"{ "build": { "dockerfile": "Dockerfile" } }"#,
+    )
+    .unwrap();
+    fs::write(dev_dir.join("Dockerfile"), "FROM scratch\n").unwrap();
+
+    let home_dir = repo_dir.path().join("home");
+    fs::create_dir(&home_dir).unwrap();
+    let repo_name = repo_dir.path().file_name().unwrap().to_str().unwrap();
+    let worktree_path = home_dir
+        .join("worktrees")
+        .join(repo_name)
+        .join("new-branch");
+
+    let podman_dir = tempdir().unwrap();
+    let podman_path = podman_dir.path().join("podman");
+    fs::write(&podman_path, STUB_SCRIPT).unwrap();
+    assert!(Command::new("chmod")
+        .arg("+x")
+        .arg(&podman_path)
+        .status()
+        .unwrap()
+        .success());
+
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_forest"));
+    cmd.current_dir(&repo_dir);
+    cmd.env(
+        "PATH",
+        format!(
+            "{}:{}",
+            podman_dir.path().display(),
+            std::env::var("PATH").unwrap()
+        ),
+    );
+    cmd.env("HOME", &home_dir);
+    cmd.env("WORKTREE_PATH", &worktree_path);
+    cmd.env("PODMAN_STATE", podman_dir.path());
+    cmd.arg("open").arg("new-branch");
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+
+    let mut child = cmd.spawn().unwrap();
+    {
+        let stdin = child.stdin.as_mut().unwrap();
+        stdin.write_all(b"git branch --show-current\n").unwrap();
+    }
+    let output = child.wait_with_output().unwrap();
+    assert!(output.status.success());
+    let out = String::from_utf8_lossy(&output.stdout);
+    assert!(out.contains("new-branch"));
+
+    assert!(podman_dir.path().join("new-branch-image.build").exists());
 }


### PR DESCRIPTION
## Summary
- allow devcontainer.json to specify a Dockerfile
- document Dockerfile usage in README
- add Dockerfile-based devcontainer config
- handle `podman build` in CLI
- update integration tests for build functionality

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f65c2c3b48326a2034917f7f8c0b0