### PR TITLE
Configure goose with openrouter

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,12 @@
 # .devcontainer/Dockerfile
 FROM mcr.microsoft.com/devcontainers/rust:latest
-RUN apt update && apt install -y libxcb1 libxcb1-dev libdbus-1-3 nvi
-RUN curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+
+# Install extra dependencies required by Goose
+RUN apt update && apt install -y \
+    libxcb1 libxcb1-dev libdbus-1-3 nvi
+
+# Install Goose preconfigured to use OpenRouter's o4-mini model
+ENV GOOSE_PROVIDER=openrouter \
+    GOOSE_MODEL=o4-mini
+RUN curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \
+    | CONFIGURE=false bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
     "name": "Rust Development Environment",
     "build": { "dockerfile": "Dockerfile" },
+    "remoteEnv": {
+        "OPENROUTER_API_KEY": "${localEnv:OPENROUTER_API_KEY}"
+    },
     "customizations": {
         "vscode": {
             "extensions": [

--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ using the latest Ubuntu image.
 ## configuration
 
 ~/.config/forest.toml
+
+## Passing credentials to the devcontainer
+
+The devcontainer uses Goose with the `openrouter` provider. To authenticate with
+OpenRouter you need to pass an API key. Set `OPENROUTER_API_KEY` in your local
+environment before launching a session and the value will be forwarded into the
+container via `remoteEnv` in `.devcontainer/devcontainer.json`.
+
+```bash
+export OPENROUTER_API_KEY=your-key-here
+forest open my-session
+```


### PR DESCRIPTION
## Summary
- set goose provider/model in Dockerfile
- forward OPENROUTER_API_KEY into devcontainer
- document how to pass the API key

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f6a9a7924832681f513012476b45c