### PR TITLE
Configure Goose with static config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,3 +10,6 @@ ENV GOOSE_PROVIDER=openrouter \
     GOOSE_MODEL=o4-mini
 RUN curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \
     | CONFIGURE=false bash
+
+# Copy static Goose configuration
+COPY goose-config.yaml /home/vscode/.config/goose/config.yaml

--- a/.devcontainer/goose-config.yaml
+++ b/.devcontainer/goose-config.yaml
@@ -1,0 +1,13 @@
+GOOSE_PROVIDER: "openrouter"
+GOOSE_MODEL: "o4-mini"
+GOOSE_TEMPERATURE: 0.2
+GOOSE_MODE: "auto"
+GOOSE_CLI_MIN_PRIORITY: 0.3
+
+extensions:
+  developer:
+    bundled: true
+    enabled: true
+    name: developer
+    timeout: 300
+    type: builtin

--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ OpenRouter you need to pass an API key. Set `OPENROUTER_API_KEY` in your local
 environment before launching a session and the value will be forwarded into the
 container via `remoteEnv` in `.devcontainer/devcontainer.json`.
 
+The container includes a static Goose configuration located at
+`/home/vscode/.config/goose/config.yaml` which sets the provider to
+`openrouter` and defaults to the `o4-mini` model. You can inspect the source
+file at `.devcontainer/goose-config.yaml`.
+
 ```bash
 export OPENROUTER_API_KEY=your-key-here
 forest open my-session


### PR DESCRIPTION
## Summary
- add goose-config.yaml with provider `openrouter`
- copy static configuration into the image via Dockerfile
- mention the baked in Goose config in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f6fbc3d148326b2321579b249a81f