### PR TITLE
Run tests via Docker with cargo-chef cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,20 +10,20 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - name: Build test image (cached)
+        uses: docker/build-push-action@v6
         with:
-          toolchain: stable
-          override: true
-      - name: Configure git
-        run: |
-          git config --global user.name "CI"
-          git config --global user.email "ci@example.com"
-      - name: Cache gh and podman
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: gh podman
-          version: 1
+          context: .
+          file: ./Dockerfile
+          target: builder
+          tags: forest:builder
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
       - name: Run tests
-        run: cargo test --verbose
+        run: |
+          docker run --rm forest:builder bash -c "git config --global user.name 'CI' && git config --global user.email 'ci@example.com' && cargo test --verbose"
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# --- Stage 0: cargo-chef + Rust toolchain
+FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+WORKDIR /app
+
+# --- Stage 1: compute dependency "recipe"
+FROM chef AS planner
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# --- Stage 2: build deps, then the binary
+FROM chef AS builder
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release --bin forest
+
+# --- Stage 3: tiny runtime
+FROM debian:bookworm-slim
+COPY --from=builder /app/target/release/forest /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/forest"]


### PR DESCRIPTION
## Summary
- remove unused docker workflow
- update test workflow to build cargo-chef image and run tests inside it using Buildx cache

## Testing
- `cargo fmt -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684f71d95cac8326aa9c3cc00b96b8da