### PR TITLE
Update Goose config path

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,5 +11,9 @@ ENV GOOSE_PROVIDER=openrouter \
 RUN curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \
     | CONFIGURE=false bash
 
-# Copy static Goose configuration
-COPY goose-config.yaml /home/vscode/.config/goose/config.yaml
+# Copy static Goose configuration to the default location for any user
+COPY goose-config.yaml /tmp/goose-config.yaml
+RUN mkdir -p /root/.config/goose && cp /tmp/goose-config.yaml /root/.config/goose/config.yaml && \
+    if id vscode 2>/dev/null; then \
+        mkdir -p /home/vscode/.config/goose && cp /tmp/goose-config.yaml /home/vscode/.config/goose/config.yaml; \
+    fi && rm /tmp/goose-config.yaml

--- a/README.md
+++ b/README.md
@@ -51,14 +51,15 @@ OpenRouter you need to pass an API key. Set `OPENROUTER_API_KEY` in your local
 environment before launching a session and the value will be forwarded into the
 container via `remoteEnv` in `.devcontainer/devcontainer.json`.
 
-The container includes a static Goose configuration located at
-`/home/vscode/.config/goose/config.yaml` which sets the provider to
-`openrouter` and defaults to the `o4-mini` model. You can inspect the source
-file at `.devcontainer/goose-config.yaml`.
+Goose reads its configuration from `~/.config/goose/config.yaml`. The
+devcontainer ships with a preconfigured file at this path that sets the
+provider to `openrouter` and defaults to the `o4-mini` model. You can inspect
+the source file at `.devcontainer/goose-config.yaml`.
 
 ```bash
 export OPENROUTER_API_KEY=your-key-here
 forest open my-session
+echo "" | goose
 
 ## Sample Session
 


### PR DESCRIPTION
## Summary
- place Goose config in ~/.config so it works for any user
- document running Goose inside the devcontainer

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f790d8e5883269b71cfd48274a3ed