### PR TITLE
Forward devcontainer remoteEnv variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,6 @@ dependencies = [
  "clap",
  "directories",
  "serde",
- "serde_json",
  "tempfile",
  "toml",
 ]
@@ -222,12 +221,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itoa"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
@@ -324,12 +317,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,18 +334,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.140"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 [dependencies]
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 toml = "0.7"
 directories = "5"
 anyhow = "1"

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Forest reads configuration from `~/.config/forest.toml`.
 
 The devcontainer uses Goose with the `openrouter` provider. To authenticate with
 OpenRouter you need to pass an API key. Set `OPENROUTER_API_KEY` in your local
-environment before launching a session and the value will be forwarded into the
-container via `remoteEnv` in `.devcontainer/devcontainer.json`.
+environment before launching a session. `forest` uses the Dev Container CLI to
+start the container, so variables defined in the `remoteEnv` section of
+`devcontainer.json` (like `OPENROUTER_API_KEY`) are automatically forwarded.
 
 Goose reads its configuration from `~/.config/goose/config.yaml`. The
 devcontainer ships with a preconfigured file at this path that sets the


### PR DESCRIPTION
## Summary
- run sessions with the Dev Container CLI instead of manual podman commands
- environment variables from `remoteEnv` are automatically forwarded
- update tests for the new CLI stub

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684f7cd716648326b0309d7b77f9548e