### PR TITLE
Switch to devcontainer CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Forest
 
 Forest is an opinionated Rust tool for starting and switching between
-Podman/devcontainer environments.
+devcontainer environments.
 
 Each session runs on its own Git branch (named the same as the session) and
 expects a remote named `origin`.
@@ -13,7 +13,7 @@ All Git operations are handled outside the container.
 ## Requirements
 - `gh` from GitHub
 - `git`
-- `podman`
+- `devcontainer` CLI
 
 The repository must include a `devcontainer.json` file. The tool searches in
 the following locations (in order):


### PR DESCRIPTION
## Summary
- switch code to use the `devcontainer` CLI instead of Podman directly
- update tests for devcontainer usage
- document new requirement in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f83005f3083269b97d72fe6d908b6