### PR TITLE
Fix build with updated devcontainer CLI

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -281,8 +281,6 @@ fn open_session(
             .arg("build")
             .arg("--workspace-folder")
             .arg(&worktree_path)
-            .arg("--id-label")
-            .arg(format!("name={}", podman_name))
             .status()
             .map_err(|e| {
                 if e.kind() == std::io::ErrorKind::NotFound {

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -25,6 +25,9 @@ case "$cmd" in
           ;;
       esac
     done
+    if [ -z "$name" ]; then
+      name=$(basename "$workspace")
+    fi
     echo "$workspace" > "$DEVCONTAINER_STATE/${name}.build"
     touch "$DEVCONTAINER_STATE/$name"
     exit 0


### PR DESCRIPTION
## Summary
- update `forest open` to stop using `--id-label` for `devcontainer build`
- adjust test stub to work when `--id-label` isn't passed

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f87a4d9948326bb074d352aee698d