### PR TITLE
Mount repo root in devcontainer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -309,6 +309,12 @@ fn open_session(
         .arg(&worktree_path)
         .arg("--id-label")
         .arg(format!("name={}", podman_name))
+        .arg("--mount")
+        .arg(format!(
+            "type=bind,source={},target={}",
+            repo_root.display(),
+            repo_root.display()
+        ))
         .status()
         .map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -35,6 +35,7 @@ case "$cmd" in
   up)
     name=""
     workspace=""
+    mounts=""
     while [ "$#" -gt 0 ]; do
       case "$1" in
         --workspace-folder)
@@ -45,12 +46,17 @@ case "$cmd" in
           name=${2#name=}
           shift 2
           ;;
+        --mount)
+          mounts="$mounts $2"
+          shift 2
+          ;;
         *)
           shift
           ;;
       esac
     done
     echo "$workspace" > "$DEVCONTAINER_STATE/${name}.workspace"
+    echo "$mounts" > "$DEVCONTAINER_STATE/${name}.mounts"
     touch "$DEVCONTAINER_STATE/$name"
     exit 0
     ;;
@@ -248,6 +254,9 @@ fn mounts_repo_and_worktree() {
 
     let workspace = fs::read_to_string(podman_dir.path().join("new-branch.workspace")).unwrap();
     assert_eq!(workspace.trim(), worktree_path.to_str().unwrap());
+
+    let mounts = fs::read_to_string(podman_dir.path().join("new-branch.mounts")).unwrap();
+    assert!(mounts.contains(repo_dir.path().to_str().unwrap()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- mount repo root when starting a session so git worktrees work
- track `--mount` usage in test stub script
- test that repo root is mounted

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f9d895b008326858167276dc6f97e