### PR TITLE
Fix Goose install location

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,19 +1,24 @@
 # .devcontainer/Dockerfile
 FROM mcr.microsoft.com/devcontainers/rust:latest
 
+USER root
 # Install extra dependencies required by Goose
 RUN apt update && apt install -y \
     libxcb1 libxcb1-dev libdbus-1-3 nvi
 
+USER vscode
 # Install Goose preconfigured to use OpenRouter's o4-mini model
 ENV GOOSE_PROVIDER=openrouter \
     GOOSE_MODEL=o4-mini
 RUN curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \
     | CONFIGURE=false bash
 
-# Copy static Goose configuration to the default location for any user
+USER root
+# Copy static Goose configuration for the vscode user
 COPY goose-config.yaml /tmp/goose-config.yaml
-RUN mkdir -p /root/.config/goose && cp /tmp/goose-config.yaml /root/.config/goose/config.yaml && \
-    if id vscode 2>/dev/null; then \
-        mkdir -p /home/vscode/.config/goose && cp /tmp/goose-config.yaml /home/vscode/.config/goose/config.yaml; \
-    fi && rm /tmp/goose-config.yaml
+RUN mkdir -p /home/vscode/.config/goose && \
+    cp /tmp/goose-config.yaml /home/vscode/.config/goose/config.yaml && \
+    chown -R vscode:vscode /home/vscode/.config/goose && \
+    rm /tmp/goose-config.yaml
+
+USER vscode


### PR DESCRIPTION
## Summary
- install Goose as the `vscode` user and keep config under that home directory

## Testing
- `cargo test`
- `cargo fmt -- --check`

------
https://chatgpt.com/codex/tasks/task_e_684fa22093788326a4fcd66cb2e5d405