### PR TITLE
Mount repo to /repo in container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,9 +2,11 @@
 FROM mcr.microsoft.com/devcontainers/rust:latest
 
 USER root
-# Install extra dependencies required by Goose
+# Install extra dependencies required by Goose and create
+# directories for bind mounts
 RUN apt update && apt install -y \
-    libxcb1 libxcb1-dev libdbus-1-3 nvi
+    libxcb1 libxcb1-dev libdbus-1-3 nvi && \
+    mkdir -p /repo /code
 
 USER vscode
 # Install Goose preconfigured to use OpenRouter's o4-mini model

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,6 @@
     "build": { "dockerfile": "Dockerfile" },
     "remoteEnv": {
         "OPENROUTER_API_KEY": "${localEnv:OPENROUTER_API_KEY}"
-    }
+    },
+    "workspaceFolder": "/code"
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,10 @@ use serde_json::Value;
 
 use std::process::Stdio;
 
-fn run_command_verbose(cmd: &mut Command, verbose: bool) -> std::io::Result<std::process::ExitStatus> {
+fn run_command_verbose(
+    cmd: &mut Command,
+    verbose: bool,
+) -> std::io::Result<std::process::ExitStatus> {
     if verbose {
         println!("Running: {:?}", cmd);
     }
@@ -247,22 +250,9 @@ fn open_session(
 
     if !worktree_path.exists() {
         if verbose {
-            println!("Creating worktree at {}", worktree_path.display());
+            println!("Creating worktree directory {}", worktree_path.display());
         }
-        fs::create_dir_all(&worktree_root)?;
-        let mut cmd = Command::new("git");
-        cmd.args([
-            "worktree",
-            "add",
-            "-B",
-            name,
-            worktree_path.to_str().unwrap(),
-        ])
-        .current_dir(&repo_root);
-        let status = run_command_verbose(&mut cmd, verbose)?;
-        if !status.success() {
-            anyhow::bail!("git worktree add failed");
-        }
+        fs::create_dir_all(&worktree_path)?;
     }
     let devcontainer_path = find_devcontainer(dev_env)?;
 
@@ -283,9 +273,7 @@ fn open_session(
             .arg(&worktree_path);
         let status = run_command_verbose(&mut cmd, verbose).map_err(|e| {
             if e.kind() == std::io::ErrorKind::NotFound {
-                anyhow::anyhow!(
-                    "devcontainer command not found. Please install @devcontainers/cli"
-                )
+                anyhow::anyhow!("devcontainer command not found. Please install @devcontainers/cli")
             } else {
                 e.into()
             }
@@ -303,9 +291,13 @@ fn open_session(
         .arg(format!("name={}", podman_name))
         .arg("--mount")
         .arg(format!(
-            "type=bind,source={},target={}",
-            repo_root.display(),
+            "type=bind,source={},target=/repo",
             repo_root.display()
+        ))
+        .arg("--mount")
+        .arg(format!(
+            "type=bind,source={},target=/code",
+            worktree_path.display()
         ));
     let status = run_command_verbose(&mut cmd, verbose).map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
@@ -318,13 +310,45 @@ fn open_session(
         anyhow::bail!("devcontainer up failed");
     }
     println!("Started session {}", name);
+
+    let git_file = worktree_path.join(".git");
+    let mut need_worktree = true;
+    if let Ok(content) = fs::read_to_string(&git_file) {
+        if content.contains("/repo/.git/worktrees/") {
+            need_worktree = false;
+        }
+    }
+    if need_worktree {
+        let mut cmd = Command::new("devcontainer");
+        cmd.arg("exec")
+            .arg("--workspace-folder")
+            .arg(&worktree_path)
+            .arg("--id-label")
+            .arg(format!("name={}", podman_name))
+            .arg("bash")
+            .arg("-lc")
+            .arg(format!("git -C /repo worktree add -B {} /code", name));
+        let status = run_command_verbose(&mut cmd, verbose).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                anyhow::anyhow!("devcontainer command not found. Please install @devcontainers/cli")
+            } else {
+                e.into()
+            }
+        })?;
+        if !status.success() {
+            anyhow::bail!("git worktree add failed");
+        }
+    }
+
     let mut cmd = Command::new("devcontainer");
     cmd.arg("exec")
         .arg("--workspace-folder")
         .arg(&worktree_path)
         .arg("--id-label")
         .arg(format!("name={}", podman_name))
-        .arg("bash");
+        .arg("bash")
+        .arg("-lc")
+        .arg("cd /code && exec bash");
     let status = run_command_verbose(&mut cmd, verbose).map_err(|e| {
         if e.kind() == std::io::ErrorKind::NotFound {
             anyhow::anyhow!("devcontainer command not found. Please install @devcontainers/cli")

--- a/tests/session.rs
+++ b/tests/session.rs
@@ -73,9 +73,12 @@ case "$cmd" in
           ;;
       esac
     done
-    input=$(cat)
+    cmd="$*"
+    if [ -z "$cmd" ]; then
+      cmd=$(cat)
+    fi
     cd "$workspace"
-    sh -c "$input"
+    sh -c "$cmd"
     exit 0
     ;;
   down)


### PR DESCRIPTION
## Summary
- revert the user-specific `postCreateCommand`
- create `/repo` and `/code` in the devcontainer image
- set `workspaceFolder` to `/code`
- mount the repo to `/repo` and the worktree to `/code`
- create the git worktree inside the container so the `.git` file points at `/repo`
- open the shell in `/code`

## Testing
- `cargo fmt --all -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684fa5f9dc308326aa1d4eb9caec775c